### PR TITLE
Add modernization plan and update README for fork ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ To install:
 1.  Install gvm:
 
     ```
-    bash < <(curl -s -S -L https://raw.githubusercontent.com/clcollins/gvm/main/binscripts/gvm-installer)
+    SRC_REPO=https://github.com/clcollins/gvm.git bash < <(curl -s -S -L https://raw.githubusercontent.com/clcollins/gvm/main/binscripts/gvm-installer) main
     ```
 
-Or if you are using zsh just change `bash` with `zsh`
+    Note: The `SRC_REPO` variable is needed until the installer is updated to default to this fork. The installer script requires `bash` regardless of your login shell.
 
 Installing Go
 =============

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Additional options can be specified when installing Go:
 
 ### Compiling Go from Source
 
-Go 1.5+ removed the C compilers from the toolchain and [replaced][compiler_note] them with one written in Go. This means you need an existing Go installation to compile from source. Go 1.20+ requires Go 1.17.13+ as a bootstrap compiler.
+Go 1.5+ removed the C compilers from the toolchain and [replaced][compiler_note] them with one written in Go. This means you need an existing Go installation to compile from source. Each Go version requires a recent-enough bootstrap compiler (typically within the last two major releases).
 
 The simplest bootstrap path:
 
@@ -78,10 +78,10 @@ gvm install go1.21.0 -B
 gvm use go1.21.0
 ```
 
-And then, compile any other version:
+And then, compile any other version (including older ones):
 
 ```
-gvm install go1.20.7
+gvm install go1.22.5
 ```
 
 [compiler_note]: https://docs.google.com/document/d/1OaatvGhEAq7VseQ9kkavxKNAfepWy2yhPUBs96FGV28/edit

--- a/README.md
+++ b/README.md
@@ -1,36 +1,28 @@
-# gvm
-
-[![Build Status](https://travis-ci.org/moovweb/gvm.svg?branch=master)](https://travis-ci.org/moovweb/gvm)
-
-By Josh Bussdieker (jbuss, jaja, jbussdieker) while working at [Moovweb](https://www.moovweb.com)
-
-Currently lovingly maintained by [Benjamin Knigge](https://github.com/BenKnigge)
-
-Pull requests and other any other contributions would be very much appreciated.
+# gvm — Go Version Manager
 
 GVM provides an interface to manage Go versions.
 
+> **Note:** This is a fork of [moovweb/gvm](https://github.com/moovweb/gvm), which was abandoned in August 2023 (last commit: 2023-08-14). The upstream repository has had no maintenance, review activity, or response to pull requests since then. This fork is independently maintained by [Chris Collins](https://github.com/clcollins).
+>
+> Originally created by Josh Bussdieker while working at [Moovweb](https://www.moovweb.com), and previously maintained by [Benjamin Knigge](https://github.com/BenKnigge).
+
+Pull requests and other contributions are welcome.
+
 Features
 ========
-* Install/Uninstall Go versions with `gvm install [tag]` where tag is "60.3", "go1", "weekly.2011-11-08", or "tip"
+* Install/Uninstall Go versions with `gvm install [tag]` where tag is "go1.22.5", "go1.23rc1", or "tip"
 * List added/removed files in GOROOT with `gvm diff`
 * Manage GOPATHs with `gvm pkgset [create/use/delete] [name]`. Use `--local` as `name` to manage repository under local path (`/path/to/repo/.gvm_local`).
 * List latest release tags with `gvm listall`. Use `--all` to list weekly as well.
 * Cache a clean copy of the latest Go source for multiple version installs.
 * Link project directories into GOPATH
 
-Background
-==========
-When we started developing in Go mismatched dependencies and API changes plagued our build process and made it extremely difficult to merge with other peoples changes.
-
-After nuking my entire GOROOT several times and rebuilding I decided to come up with a tool to oversee the process. It eventually evolved into what gvm is today.
-
 Installing
 ==========
 
 To install:
 
-1.  Install [Bison](https://www.gnu.org/software/bison/):
+1.  Install [Bison](https://www.gnu.org/software/bison/) (only needed if building Go from source):
 
     ```
     sudo apt-get install bison
@@ -39,15 +31,19 @@ To install:
 1.  Install gvm:
 
     ```
-    bash < <(curl -s -S -L https://raw.githubusercontent.com/moovweb/gvm/master/binscripts/gvm-installer)
+    bash < <(curl -s -S -L https://raw.githubusercontent.com/clcollins/gvm/main/binscripts/gvm-installer)
     ```
 
 Or if you are using zsh just change `bash` with `zsh`
 
 Installing Go
 =============
-    gvm install go1.4
-    gvm use go1.4 [--default]
+
+The quickest way to install a Go version is with the `--prefer-binary` flag, which downloads a precompiled binary from go.dev and only falls back to source compilation if no binary is available for your platform:
+
+    gvm install go1.22.5 --prefer-binary
+    gvm use go1.22.5 [--default]
+
 Once this is done Go will be in the path and ready to use. $GOROOT and $GOPATH are set automatically.
 
 Additional options can be specified when installing Go:
@@ -60,15 +56,18 @@ Additional options can be specified when installing Go:
         -B,  --binary             Only install from binary.
              --prefer-binary      Attempt a binary install, falling back to source.
         -h,  --help               Display this message.
-        
-### A Note on Compiling Go 1.5+
-Go 1.5+ removed the C compilers from the toolchain and [replaced][compiler_note] them with one written in Go. Obviously, this creates a bootstrapping problem if you don't already have a working Go install. In order to compile Go 1.5+, make sure Go 1.4 is installed first. If Go 1.4 won't install try a later version (e.g. go1.5), just make sure you have the `-B` option after the version number. 
+
+### Compiling Go from Source
+
+Go 1.5+ removed the C compilers from the toolchain and [replaced][compiler_note] them with one written in Go. This means you need an existing Go installation to compile from source. Go 1.20+ requires Go 1.17.13+ as a bootstrap compiler.
+
+The simplest bootstrap path:
 
 ```
-gvm install go1.4 -B
-gvm use go1.4
+gvm install go1.17.13 -B
+gvm use go1.17.13
 export GOROOT_BOOTSTRAP=$GOROOT
-gvm install go1.7
+gvm install go1.22.5
 ```
 
 ### A Note on ARMv6 and ARMv7 architectures (32 bit)
@@ -83,20 +82,6 @@ And then, compile any other version:
 
 ```
 gvm install go1.20.7
-```
-
-#### To install Go 1.20+
-Go 1.20+ requires go1.17.3+. Use the below:
-
-```
-gvm install go1.4 -B
-gvm use go1.4
-export GOROOT_BOOTSTRAP=$GOROOT
-gvm install go1.17.13
-gvm use go1.17.13
-export GOROOT_BOOTSTRAP=$GOROOT
-gvm install go1.20
-gvm use go1.20
 ```
 
 [compiler_note]: https://docs.google.com/document/d/1OaatvGhEAq7VseQ9kkavxKNAfepWy2yhPUBs96FGV28/edit
@@ -121,13 +106,10 @@ If that doesn't work see the troubleshooting steps at the bottom of this page.
 
 Mac OS X Requirements
 ====================
- * Install Mercurial from https://www.mercurial-scm.org/downloads
  * Install Xcode Command Line Tools from the App Store.
 
 ```
 xcode-select --install
-brew update
-brew install mercurial
 ```
 
 Linux Requirements
@@ -135,26 +117,18 @@ Linux Requirements
 
 Debian/Ubuntu
 ==================
-    sudo apt-get install curl git mercurial make binutils bison gcc build-essential
+    sudo apt-get install curl git make binutils bison gcc build-essential
 
-Redhat/Centos
+Redhat/Centos/Fedora
 ==================
 
-    sudo yum install curl
-    sudo yum install git
-    sudo yum install make
-    sudo yum install bison
-    sudo yum install gcc
-    sudo yum install glibc-devel
-
- * Install Mercurial from http://pkgs.repoforge.org/mercurial/
+    sudo dnf install curl git make bison gcc glibc-devel
 
 FreeBSD Requirements
 ====================
 
     sudo pkg_add -r bash
     sudo pkg_add -r git
-    sudo pkg_add -r mercurial
 
 Vendoring Native Code and Dependencies
 ==================================================
@@ -189,7 +163,7 @@ system provides:
 
 Recipe for success:
 
-    gvm use go1.1
+    gvm use go1.22
     gvm pkgset use current-known-good
     # Let's assume that this includes some C headers and native libraries, which
     # Go's CGO facility wraps for us.  Let's assume that these native
@@ -206,5 +180,3 @@ See examples/native for a working example.
 Troubleshooting
 ===============
 Sometimes especially during upgrades the state of gvm's files can get mixed up. This is mostly true for upgrade from older version than 0.0.8. Changes are slowing down and a LTR is imminent. But for now `rm -rf ~/.gvm` will always remove gvm. Stay tuned!
-
-[![Gitter](https://badges.gitter.im/GoVesionManager/community.svg)](https://gitter.im/GoVesionManager/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)

--- a/docs/plans/gvm-modernization-plan.md
+++ b/docs/plans/gvm-modernization-plan.md
@@ -19,29 +19,29 @@ This fork is now independently maintained by [Chris Collins](https://github.com/
 
 ### Phase 1: Ownership Divorce
 
-- **ISSUE_1**: Replace moovweb ownership references throughout codebase
+- [#2](https://github.com/clcollins/gvm/issues/2): Replace moovweb ownership references throughout codebase
 
 ### Phase 2: Critical Bug Fixes
 
-- **ISSUE_2**: Fix syntax errors in pkgset-use and find_local_pkgset
-- **ISSUE_3**: Fix shell compatibility and quoting issues
-- **ISSUE_4**: Add SHA256 checksum verification for binary downloads
+- [#3](https://github.com/clcollins/gvm/issues/3): Fix syntax errors in pkgset-use and find_local_pkgset
+- [#4](https://github.com/clcollins/gvm/issues/4): Fix shell compatibility and quoting issues
+- [#5](https://github.com/clcollins/gvm/issues/5): Add SHA256 checksum verification for binary downloads
 
 ### Phase 3: Infrastructure Cleanup
 
-- **ISSUE_5**: Remove dead infrastructure files (.travis.yml, Vagrantfile, Gemfile, Rakefile)
-- **ISSUE_6**: Add GitHub Actions CI and repository scaffolding
-- **ISSUE_7**: Migrate test framework from Ruby tf to bats-core
+- [#6](https://github.com/clcollins/gvm/issues/6): Remove dead infrastructure files (.travis.yml, Vagrantfile, Gemfile, Rakefile)
+- [#7](https://github.com/clcollins/gvm/issues/7): Add GitHub Actions CI and repository scaffolding
+- [#8](https://github.com/clcollins/gvm/issues/8): Migrate test framework from Ruby tf to bats-core
 
 ### Phase 4: Modernization
 
-- **ISSUE_8**: Remove legacy package managers and deprecate gvm cross
-- **ISSUE_9**: Make --prefer-binary the default installation behavior
-- **ISSUE_10**: Add go.work workspace support
+- [#9](https://github.com/clcollins/gvm/issues/9): Remove legacy package managers and deprecate gvm cross
+- [#10](https://github.com/clcollins/gvm/issues/10): Make --prefer-binary the default installation behavior
+- [#11](https://github.com/clcollins/gvm/issues/11): Add go.work workspace support
 
 ## Issue Details
 
-### ISSUE_1: Replace moovweb ownership references throughout codebase
+### #2: Replace moovweb ownership references throughout codebase
 
 **Priority**: 1 (do first)
 
@@ -65,7 +65,7 @@ Files to leave unchanged:
 
 ---
 
-### ISSUE_2: Fix syntax errors in pkgset-use and find_local_pkgset
+### #3: Fix syntax errors in pkgset-use and find_local_pkgset
 
 **Priority**: 2 (critical bugs)
 
@@ -87,7 +87,7 @@ Files to leave unchanged:
 
 ---
 
-### ISSUE_3: Fix shell compatibility and quoting issues
+### #4: Fix shell compatibility and quoting issues
 
 **Priority**: 2 (bugs)
 
@@ -107,7 +107,7 @@ Files to leave unchanged:
 
 ---
 
-### ISSUE_4: Add SHA256 checksum verification for binary downloads
+### #5: Add SHA256 checksum verification for binary downloads
 
 **Priority**: 2 (security)
 
@@ -123,7 +123,7 @@ Implementation:
 
 ---
 
-### ISSUE_5: Remove dead infrastructure files
+### #6: Remove dead infrastructure files
 
 **Priority**: 3 (cleanup)
 
@@ -131,16 +131,16 @@ Delete:
 - `.travis.yml` -- Travis CI is dead
 - `Vagrantfile` -- targets Ubuntu 12.04 (Precise Pangolin), EOL since 2017
 - `Gemfile` -- only existed for Ruby `tf` test framework
-- `Rakefile` -- test runner for `tf`; replaced by bats in Issue 7
+- `Rakefile` -- test runner for `tf`; replaced by bats in #8
 
 **Acceptance criteria**: Files deleted, no Ruby dependencies remain.
 
 ---
 
-### ISSUE_6: Add GitHub Actions CI and repository scaffolding
+### #7: Add GitHub Actions CI and repository scaffolding
 
 **Priority**: 3 (infrastructure)
-**Depends on**: ISSUE_7 (bats migration, for test runner)
+**Depends on**: #8 (bats migration, for test runner)
 
 Create:
 - `.github/workflows/ci.yml` -- CI on push to main + PRs; Ubuntu + macOS matrix; runs shellcheck + bats
@@ -153,7 +153,7 @@ Create:
 
 ---
 
-### ISSUE_7: Migrate test framework from Ruby tf to bats-core
+### #8: Migrate test framework from Ruby tf to bats-core
 
 **Priority**: 3 (testing)
 
@@ -169,10 +169,10 @@ Steps:
 
 ---
 
-### ISSUE_8: Remove legacy package managers and deprecate gvm cross
+### #9: Remove legacy package managers and deprecate gvm cross
 
 **Priority**: 4 (modernization)
-**Depends on**: ISSUE_1 (to avoid merge conflicts on same moovweb lines)
+**Depends on**: #2 (to avoid merge conflicts on same moovweb lines)
 
 1. Remove `install_gpkg()`, `install_gb()`, `install_goprotobuf()` from `scripts/install` (lines 254-295). These install from dead URLs.
 2. Remove `--with-protobuf` and `--with-build-tools` flags from install.
@@ -183,7 +183,7 @@ Steps:
 
 ---
 
-### ISSUE_9: Make --prefer-binary the default installation behavior
+### #10: Make --prefer-binary the default installation behavior
 
 **Priority**: 4 (modernization)
 
@@ -200,7 +200,7 @@ Changes:
 
 ---
 
-### ISSUE_10: Add go.work workspace support
+### #11: Add go.work workspace support
 
 **Priority**: 4 (modernization)
 
@@ -214,17 +214,17 @@ Go 1.18+ supports workspace files (`go.work`). GVM should recognize them:
 ## Dependency Graph
 
 ```
-ISSUE_1 (ownership) ─────────────────────────────> ISSUE_8 (legacy removal)
-ISSUE_2 (syntax bugs)      [independent]
-ISSUE_3 (shell compat)     [independent]
-ISSUE_4 (checksums)         [independent]
-ISSUE_5 (dead files)        [independent]
-ISSUE_7 (bats migration) ──────────────────────────> ISSUE_6 (GitHub Actions CI)
-ISSUE_9 (binary default)   [independent]
-ISSUE_10 (go.work)          [independent]
+#2  (ownership) ──────────────────────────────────> #9  (legacy removal)
+#3  (syntax bugs)      [independent]
+#4  (shell compat)     [independent]
+#5  (checksums)         [independent]
+#6  (dead files)        [independent]
+#8  (bats migration) ──────────────────────────────> #7  (GitHub Actions CI)
+#10 (binary default)   [independent]
+#11 (go.work)          [independent]
 ```
 
-Issues 1-5, 7, 9, 10 can all be worked independently. Issue 6 should land after Issue 7. Issue 8 should land after Issue 1.
+Issues #2-6, #8, #10, #11 can all be worked independently. Issue #7 should land after #8. Issue #9 should land after #2.
 
 ## Definition of Done
 

--- a/docs/plans/gvm-modernization-plan.md
+++ b/docs/plans/gvm-modernization-plan.md
@@ -73,7 +73,7 @@ Files to leave unchanged:
    ```
    elif [[ "${local_pkgset_rematch}" == true ]] && $(( ${#accumulator[@]}%2 )) -eq 0 ]]; then
    ```
-   Missing opening `[[` before arithmetic test. The `$((` creates a command substitution instead of an arithmetic comparison inside `[[ ]]`.
+   Missing opening `[[` before the arithmetic comparison. `$(( ... ))` is arithmetic expansion, and here the comparison is written outside `[[ ... ]]`, causing invalid shell syntax.
 
 2. `scripts/function/find_local_pkgset:7,13` -- broken PWD assignment:
    ```

--- a/docs/plans/gvm-modernization-plan.md
+++ b/docs/plans/gvm-modernization-plan.md
@@ -61,7 +61,7 @@ Files to delete:
 Files to leave unchanged:
 - `ChangeLog` -- historical record
 
-**Acceptance criteria**: `grep -r moovweb` returns zero results outside ChangeLog.
+**Acceptance criteria**: `grep -r moovweb binscripts/ scripts/ extra/ AUTHORS LICENSE` returns zero results. Documentation files (`README.md`, `docs/`) may retain upstream attribution and migration context. `ChangeLog` is excluded as historical record.
 
 ---
 
@@ -228,7 +228,7 @@ Issues #2-6, #8, #10, #11 can all be worked independently. Issue #7 should land 
 
 ## Definition of Done
 
-- [ ] All moovweb references replaced (except ChangeLog)
+- [ ] moovweb ownership references replaced in code, config, packaging, and active project metadata; historical/upstream attribution preserved in documentation
 - [ ] Critical syntax errors fixed (pkgset-use, find_local_pkgset)
 - [ ] Shell compatibility issues resolved
 - [ ] Binary downloads verified with SHA256

--- a/docs/plans/gvm-modernization-plan.md
+++ b/docs/plans/gvm-modernization-plan.md
@@ -1,0 +1,240 @@
+# GVM Modernization Plan
+
+## Overview
+
+This repository is a fork of [moovweb/gvm](https://github.com/moovweb/gvm), a Go Version Manager written in bash. The upstream project was abandoned in August 2023 (last commit: 2023-08-14). No maintenance, review activity, or response to pull requests has occurred since.
+
+This fork is now independently maintained by [Chris Collins](https://github.com/clcollins). A deep analysis of the codebase revealed critical bugs, security issues, dead infrastructure, and modernization opportunities. This plan tracks the work needed to establish independent ownership, fix bugs, and bring the project up to date with modern Go (1.22+).
+
+## Current State Assessment
+
+- **License**: MIT -- permits forking, modification, and redistribution
+- **Tests**: 11 test files using Ruby `tf` framework, ~30% feature coverage, 3 tests with no assertions
+- **CI**: Travis CI (dead), no GitHub Actions
+- **Bugs**: Syntax errors in pkgset-use and find_local_pkgset, broken shell compatibility
+- **Security**: No checksum verification on binary Go downloads
+- **Ownership**: Multiple files still reference moovweb
+
+## Phases
+
+### Phase 1: Ownership Divorce
+
+- **ISSUE_1**: Replace moovweb ownership references throughout codebase
+
+### Phase 2: Critical Bug Fixes
+
+- **ISSUE_2**: Fix syntax errors in pkgset-use and find_local_pkgset
+- **ISSUE_3**: Fix shell compatibility and quoting issues
+- **ISSUE_4**: Add SHA256 checksum verification for binary downloads
+
+### Phase 3: Infrastructure Cleanup
+
+- **ISSUE_5**: Remove dead infrastructure files (.travis.yml, Vagrantfile, Gemfile, Rakefile)
+- **ISSUE_6**: Add GitHub Actions CI and repository scaffolding
+- **ISSUE_7**: Migrate test framework from Ruby tf to bats-core
+
+### Phase 4: Modernization
+
+- **ISSUE_8**: Remove legacy package managers and deprecate gvm cross
+- **ISSUE_9**: Make --prefer-binary the default installation behavior
+- **ISSUE_10**: Add go.work workspace support
+
+## Issue Details
+
+### ISSUE_1: Replace moovweb ownership references throughout codebase
+
+**Priority**: 1 (do first)
+
+Files to update:
+- `binscripts/gvm-installer:58` -- `SRC_REPO` default URL
+- `scripts/pkgset:20` -- comment URL
+- `scripts/alias:13` -- comment URL
+- `scripts/linkthis:12` -- example referencing `github.com/moovweb/gpkg`
+- `scripts/install:256` -- `github.com/moovweb/gpkg` go install reference
+- `extra/DEBIAN/control:4` -- maintainer email
+- `AUTHORS` -- add current maintainer
+- `LICENSE` -- preserve original copyright, add clcollins copyright line
+
+Files to delete:
+- `config/sources` -- contains `git://github.com/moovweb`, unreferenced by any script
+
+Files to leave unchanged:
+- `ChangeLog` -- historical record
+
+**Acceptance criteria**: `grep -r moovweb` returns zero results outside ChangeLog.
+
+---
+
+### ISSUE_2: Fix syntax errors in pkgset-use and find_local_pkgset
+
+**Priority**: 2 (critical bugs)
+
+1. `scripts/env/pkgset-use:92` -- mismatched brackets in elif:
+   ```
+   elif [[ "${local_pkgset_rematch}" == true ]] && $(( ${#accumulator[@]}%2 )) -eq 0 ]]; then
+   ```
+   Missing opening `[[` before arithmetic test. The `$((` creates a command substitution instead of an arithmetic comparison inside `[[ ]]`.
+
+2. `scripts/function/find_local_pkgset:7,13` -- broken PWD assignment:
+   ```
+   PWD= /bin/pwd
+   ```
+   Sets PWD to empty and runs `/bin/pwd` as a separate command. Should be `PWD=$(/bin/pwd)`. The function never returns the current directory when `.gvm_local` is found.
+
+**Note**: `scripts/env/cd:109` calling `__gvmp_find_closest_dot_go_version` is NOT a bug -- the function is defined at line 163 of the same file and resolves correctly at call time.
+
+**Acceptance criteria**: `bash -n` on both files exits 0; `find_local_pkgset` correctly returns directory containing `.gvm_local`.
+
+---
+
+### ISSUE_3: Fix shell compatibility and quoting issues
+
+**Priority**: 2 (bugs)
+
+1. `binscripts/gvm-installer:117` -- uses `finger` command (deprecated, missing on modern macOS). Replace with `dscl . -read /Users/$(id -u -n) UserShell | awk '{print $2}'`.
+
+2. `binscripts/gvm-installer:23,68` -- uses `which` instead of `command -v`. `which` is not POSIX and behaves inconsistently.
+
+3. `scripts/function/extract_version:8` -- unquoted `$1` in grep: `if [ $(echo $1 | grep release) ]`. Should be `if echo "$1" | grep -q "release"`.
+
+4. `scripts/function/display_{error,message,warning,fatal}` -- TERM check uses exact match `$TERM == "xterm"`. Most modern terminals report `xterm-256color`. Change to pattern match: `$TERM == xterm*`.
+
+5. `scripts/env/applymod` -- unquoted variables in grep patterns (lines 11, 15). Risk of glob expansion and word splitting.
+
+6. Audit all scripts for additional unquoted variable expansions in dangerous contexts.
+
+**Acceptance criteria**: `gvm-installer` works on macOS without `finger`; colors work in `xterm-256color` terminals; `shellcheck` reports no critical warnings on modified files.
+
+---
+
+### ISSUE_4: Add SHA256 checksum verification for binary downloads
+
+**Priority**: 2 (security)
+
+`scripts/install` downloads Go binaries via curl with no integrity verification. Go publishes SHA256 checksums alongside binaries at `https://dl.google.com/go/<filename>.sha256`.
+
+Implementation:
+1. After downloading tarball, download corresponding `.sha256` file
+2. Verify with `sha256sum -c` (Linux) or `shasum -a 256 -c` (macOS)
+3. Fail with clear error if verification fails; remove corrupt download
+4. Add `--skip-checksum` flag for edge cases (corporate proxies, etc.)
+
+**Acceptance criteria**: Binary downloads are verified; checksum mismatch produces clear error; `--skip-checksum` bypasses with a warning.
+
+---
+
+### ISSUE_5: Remove dead infrastructure files
+
+**Priority**: 3 (cleanup)
+
+Delete:
+- `.travis.yml` -- Travis CI is dead
+- `Vagrantfile` -- targets Ubuntu 12.04 (Precise Pangolin), EOL since 2017
+- `Gemfile` -- only existed for Ruby `tf` test framework
+- `Rakefile` -- test runner for `tf`; replaced by bats in Issue 7
+
+**Acceptance criteria**: Files deleted, no Ruby dependencies remain.
+
+---
+
+### ISSUE_6: Add GitHub Actions CI and repository scaffolding
+
+**Priority**: 3 (infrastructure)
+**Depends on**: ISSUE_7 (bats migration, for test runner)
+
+Create:
+- `.github/workflows/ci.yml` -- CI on push to main + PRs; Ubuntu + macOS matrix; runs shellcheck + bats
+- `.github/CODEOWNERS` -- `* @clcollins`
+- `.github/ISSUE_TEMPLATE/bug_report.md`
+- `.github/ISSUE_TEMPLATE/feature_request.md`
+- `.github/pull_request_template.md`
+
+**Acceptance criteria**: CI runs on every PR and push to main; shellcheck and bats execute in CI.
+
+---
+
+### ISSUE_7: Migrate test framework from Ruby tf to bats-core
+
+**Priority**: 3 (testing)
+
+Steps:
+1. Create bats test structure (`tests/test_helper.bash`, `tests/*.bats`)
+2. Port existing 11 `*_comment_test.sh` files to bats format
+3. Add real assertions to 3 empty tests (gvm_list, gvm_listall, gvm_version)
+4. Add new pkgset lifecycle tests (create, use, list, empty, delete)
+5. Add error handling tests (invalid version, missing Go)
+6. Remove old tf test files and `tests/scenario/` directory
+
+**Acceptance criteria**: `bats tests/` runs successfully; existing coverage preserved; pkgset and error tests added.
+
+---
+
+### ISSUE_8: Remove legacy package managers and deprecate gvm cross
+
+**Priority**: 4 (modernization)
+**Depends on**: ISSUE_1 (to avoid merge conflicts on same moovweb lines)
+
+1. Remove `install_gpkg()`, `install_gb()`, `install_goprotobuf()` from `scripts/install` (lines 254-295). These install from dead URLs.
+2. Remove `--with-protobuf` and `--with-build-tools` flags from install.
+3. Add deprecation warning to `scripts/cross` pointing users to `GOOS=X GOARCH=Y go build`.
+4. Remove Mercurial references from docs and scripts (Go uses git exclusively now).
+
+**Acceptance criteria**: Legacy install functions removed; `gvm cross` prints deprecation warning; no Mercurial references remain.
+
+---
+
+### ISSUE_9: Make --prefer-binary the default installation behavior
+
+**Priority**: 4 (modernization)
+
+Currently `gvm install go1.X` compiles from source (6-10 minutes). Binary download takes ~10 seconds. Most users want binaries.
+
+Changes:
+1. `gvm install go1.X` with no flags attempts binary first, falls back to source
+2. Add `--source` flag for explicit source compilation
+3. `--prefer-binary` becomes a no-op (now the default)
+4. `-B`/`--binary` still works (binary-only, no fallback)
+5. Add `toolchain` directive parsing from `go.mod` to `gvm applymod` (Go 1.22+ feature)
+
+**Acceptance criteria**: Default install tries binary first; `--source` forces source; `gvm applymod` reads `toolchain go1.X.Y` from go.mod.
+
+---
+
+### ISSUE_10: Add go.work workspace support
+
+**Priority**: 4 (modernization)
+
+Go 1.18+ supports workspace files (`go.work`). GVM should recognize them:
+1. `gvm applymod` checks `go.work` for version info when present
+2. `cd` override detects `go.work` alongside `.go-version`
+3. Documentation mentions `go.work` support
+
+**Acceptance criteria**: `gvm applymod` reads version from `go.work`; documented.
+
+## Dependency Graph
+
+```
+ISSUE_1 (ownership) ─────────────────────────────> ISSUE_8 (legacy removal)
+ISSUE_2 (syntax bugs)      [independent]
+ISSUE_3 (shell compat)     [independent]
+ISSUE_4 (checksums)         [independent]
+ISSUE_5 (dead files)        [independent]
+ISSUE_7 (bats migration) ──────────────────────────> ISSUE_6 (GitHub Actions CI)
+ISSUE_9 (binary default)   [independent]
+ISSUE_10 (go.work)          [independent]
+```
+
+Issues 1-5, 7, 9, 10 can all be worked independently. Issue 6 should land after Issue 7. Issue 8 should land after Issue 1.
+
+## Definition of Done
+
+- [ ] All moovweb references replaced (except ChangeLog)
+- [ ] Critical syntax errors fixed (pkgset-use, find_local_pkgset)
+- [ ] Shell compatibility issues resolved
+- [ ] Binary downloads verified with SHA256
+- [ ] Dead infrastructure removed
+- [ ] GitHub Actions CI running
+- [ ] Test framework migrated to bats with expanded coverage
+- [ ] Legacy package managers removed
+- [ ] Binary-first installation is the default
+- [ ] go.work workspace support added


### PR DESCRIPTION
## Summary

- Updates README.md to reflect this is a fork of moovweb/gvm (abandoned August 2023), with current maintainer attribution and modernized installation instructions
- Adds `docs/plans/gvm-modernization-plan.md` tracking all work needed to establish independent ownership, fix bugs, and modernize the project

## Plan Overview

The modernization plan covers 4 phases across 10 GitHub issues:

1. **Ownership Divorce** -- Replace moovweb references
2. **Critical Bug Fixes** -- Syntax errors, shell compatibility, checksum verification
3. **Infrastructure Cleanup** -- Remove dead CI/VM files, add GitHub Actions, migrate tests to bats
4. **Modernization** -- Binary-first installs, go.work support, deprecate legacy features

Individual GitHub issues will be created to track each work item, with one PR per issue.

Created with assistance from Claude <claude@anthropic.com>