### PR TITLE
Fix syntax errors in pkgset-use and find_local_pkgset

### DIFF
--- a/scripts/env/pkgset-use
+++ b/scripts/env/pkgset-use
@@ -89,7 +89,7 @@ gvm_pkgset_use() {
             # element in the accumulator must be the option for which this
             # regex matches, we then just add the value.
             accumulator+=( "${GVM_REMATCH[1]}" )
-        elif [[ "${local_pkgset_rematch}" == true ]] && $(( ${#accumulator[@]}%2 )) -eq 0 ]]; then
+        elif [[ "${local_pkgset_rematch}" == true ]] && [[ $(( ${#accumulator[@]}%2 )) -eq 0 ]]; then
             accumulator+=( "--local" "${GVM_REMATCH[1]}")
         elif [[ "${local_pkgset_rematch}" == true ]] && [[ -n "$(valueForKeyFakeAssocArray "--local" "${options_hash[*]}")" ]]; then
             # --local is a special case: for legacy compatibility we need to

--- a/scripts/function/find_local_pkgset
+++ b/scripts/function/find_local_pkgset
@@ -3,19 +3,19 @@
 function find_local_pkgset
 {
     local TOPFILE=.gvm_local
-    if [ -d $TOPFILE ] ; then
-        PWD= /bin/pwd
+    if [ -d "$TOPFILE" ] ; then
+        PWD=$(/bin/pwd)
+        echo "$PWD"
     else
-        local HERE=$PWD
+        local HERE="$PWD"
         T=
-        while [ \( ! \( -d $TOPFILE \) \) -a \( $PWD != "/" \) ]; do
+        while [ \( ! \( -d "$TOPFILE" \) \) -a \( "$PWD" != "/" \) ]; do
             builtin cd ..
-            T=`PWD= /bin/pwd`
+            T=$(/bin/pwd)
         done
-        builtin cd $HERE
+        builtin cd "$HERE"
         if [ -d "$T/$TOPFILE" ]; then
-            echo $T
+            echo "$T"
         fi
     fi
 }
-


### PR DESCRIPTION
## Summary

- Fix mismatched brackets in pkgset-use local_pkgset_rematch conditional (line 92)
- Fix broken PWD assignment in find_local_pkgset (was running `/bin/pwd` without capturing output)
- Add missing `echo` so find_local_pkgset returns the directory when `.gvm_local` is found
- Quote all variable expansions to prevent word splitting

## Test plan

- [ ] `bash -n scripts/env/pkgset-use` exits 0
- [ ] `bash -n scripts/function/find_local_pkgset` exits 0
- [ ] Local pkgset selection works end-to-end

Closes #3