### PR TITLE
Fix shell compatibility and quoting issues

### DIFF
--- a/binscripts/gvm-installer
+++ b/binscripts/gvm-installer
@@ -20,7 +20,7 @@ update_profile() {
 check_existing_go() {
 
 	if [ "$GOROOT" = "" ]; then
-		if which go > /dev/null 2>&1; then
+		if command -v go > /dev/null 2>&1; then
 			GOROOT=$(go env | grep GOROOT | cut -d"=" -f2)
 		else
 			echo "No existing Go versions detected"
@@ -65,7 +65,7 @@ SRC_REPO=${SRC_REPO:-https://github.com/moovweb/gvm.git}
     rm -rf $GVM_DEST/$GVM_NAME"
 
 [ -d "$GVM_DEST" ] || mkdir -p "$GVM_DEST" > /dev/null 2>&1 || display_error "Failed to create $GVM_DEST"
-[ -z "$(which git)" ] && display_error "Could not find git
+[ -z "$(command -v git)" ] && display_error "Could not find git
 
   debian/ubuntu: apt-get install git
   redhat/centos: yum install git
@@ -114,9 +114,9 @@ if [ -z "$GVM_NO_UPDATE_PROFILE" ] ; then
   if [ "$(uname)" == "Linux" ]; then
     update_profile "$HOME/.bashrc" || update_profile "$HOME/.bash_profile"
   elif [ "$(uname)" == "Darwin" ]; then
-    LOGIN_SHELL=$(finger $(id -u -n) | grep Shell | cut -d : -f 3)
-    echo "macOS detected. User shell is:" $LOGIN_SHELL
-    if [ $LOGIN_SHELL == "/bin/zsh" ]; then 		# macOS moved to ZSH after macOS Catalina
+    LOGIN_SHELL=$(dscl . -read /Users/"$(id -u -n)" UserShell | awk '{print $2}')
+    echo "macOS detected. User shell is: $LOGIN_SHELL"
+    if [ "$LOGIN_SHELL" == "/bin/zsh" ]; then 		# macOS moved to ZSH after macOS Catalina
       update_profile "$HOME/.zshrc"
     else
       update_profile "$HOME/.profile" || update_profile "$HOME/.bash_profile"

--- a/scripts/env/applymod
+++ b/scripts/env/applymod
@@ -8,12 +8,12 @@ function gvm_applymod(){
 		return $(display_error "can not find go.mod")
 	fi
 
-	mod_ver=$(cat go.mod | grep -E 'go [[:digit:]]+.[[:digit:]]+' | tr -d ' ' | tr -d '\n')
-    mod_name=$(cat go.mod | grep 'module ' | tr -d '\n')
+	mod_ver=$(grep -E 'go [[:digit:]]+\.[[:digit:]]+' go.mod | tr -d ' ' | tr -d '\n')
+    mod_name=$(grep 'module ' go.mod | tr -d '\n')
 	display_message "$mod_name use go version: $mod_ver"
 
-	if [ $(gvm list | grep $mod_ver | wc -l | tr -d '\n') -lt 1 ]; then
-		if [ $(gvm listall -a| grep $mod_ver | wc -l | tr -d '\n') -lt 1 ]; then
+	if [ "$(gvm list | grep "$mod_ver" | wc -l | tr -d '\n')" -lt 1 ]; then
+		if [ "$(gvm listall -a | grep "$mod_ver" | wc -l | tr -d '\n')" -lt 1 ]; then
 			return $(display_error "can not find a go version match $mod_ver") 
 		fi
 

--- a/scripts/function/display_error
+++ b/scripts/function/display_error
@@ -1,6 +1,6 @@
 display_error() {
 	command -v tput &> /dev/null
-	if [[ "$?" == "0" ]]  && [[ "$TERM" == "xterm" ]]; then
+	if [[ "$?" == "0" ]]  && [[ "$TERM" == xterm* ]]; then
 		tput sgr0
 		tput setaf 1
 		echo "ERROR: $1" >&2

--- a/scripts/function/display_fatal
+++ b/scripts/function/display_fatal
@@ -1,6 +1,6 @@
 display_fatal() {
 	command -v tput &> /dev/null
-	if [[ "$?" == "0" ]]  && [[ "$TERM" == "xterm" ]]; then
+	if [[ "$?" == "0" ]]  && [[ "$TERM" == xterm* ]]; then
 		tput sgr0
 		tput setaf 1
 		echo "ERROR: $1" >&2

--- a/scripts/function/display_message
+++ b/scripts/function/display_message
@@ -1,6 +1,6 @@
 display_message() {
 	command -v tput &> /dev/null
-	if [[ "$?" == "0" ]]  && [[ "$TERM" == "xterm" ]]; then
+	if [[ "$?" == "0" ]]  && [[ "$TERM" == xterm* ]]; then
 		# GREEN!
 		tput sgr0
 		tput setaf 2

--- a/scripts/function/display_warning
+++ b/scripts/function/display_warning
@@ -1,6 +1,6 @@
 display_warning() {
 	command -v tput &> /dev/null
-	if [[ "$?" == "0" ]]  && [[ "$TERM" == "xterm" ]]; then
+	if [[ "$?" == "0" ]]  && [[ "$TERM" == xterm* ]]; then
 		# YELLOW!
 		tput sgr0
 		tput setaf 3

--- a/scripts/function/extract_version
+++ b/scripts/function/extract_version
@@ -5,7 +5,7 @@ extract_version(){
 	# They can also have the suffix rc or betaN
 
 	# Early versions can be 0.0.1
-	if [ $(echo $1 | grep release) ]; then
+	if echo "$1" | grep -q "release"; then
 		echo "0.0.1"
 	else
 		# Let's strip those prefixes and suffixes


### PR DESCRIPTION
## Summary

- Replace deprecated `finger` command with `dscl` for macOS shell detection
- Replace non-POSIX `which` with `command -v` throughout installer
- Fix TERM checks to match `xterm-256color`, `screen-256color`, etc. (pattern match instead of exact)
- Quote variables in grep/test expressions in applymod to prevent word splitting
- Simplify extract_version grep pattern

## Test plan

- [ ] `gvm-installer` works on macOS without `finger` installed
- [ ] `which` is not used anywhere (replaced with `command -v`)
- [ ] Colors work in terminals reporting `xterm-256color`, `screen-256color`, etc.
- [ ] All variables in grep/test expressions are properly quoted

Closes #4